### PR TITLE
Fixed classification of R6id instances

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,7 +38,7 @@
 					<div class="table-row">
 						<div class="table-cell text-xs py-1 px-3 rounded rounded-r-none text-gray-600 bg-gray-100">Release</div>
 						<div class="table-cell text-xs py-1 px-3 rounded rounded-l-none text-white bg-aws-100">
-							<a href="https://github.com/nrollr/ec2-timeline/releases">v1.5.5</a>
+							<a href="https://github.com/nrollr/ec2-timeline/releases">v1.5.6</a>
 						</div>
 					</div>
 				</div>
@@ -83,7 +83,7 @@
 									<!-- INSTANCES -->
 									<div
 										class="mt-4 relative inline-flex items-center rounded-full border border-gray-300 px-3 py-0.5 text-sm">
-										<div class="font-medium text-sm text-gray-600">Compute Optimized</div>
+										<div class="font-medium text-sm text-gray-600">Memory Optimized</div>
 									</div>
 									<div class="mt-1 mx-3 text-gray-700">
 										<p class="font-light text-sm">Release of instances: <span


### PR DESCRIPTION
Minor change on the landing page to reflect the correct classification of R6id instances (Memory Optimized instead of Compute Optimized - see issue #15  